### PR TITLE
89 - Throw Die in the Mouse Direction - QoL

### DIFF
--- a/GatekeeperStudyHall/Assets/Scripts/DiceRoll.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/DiceRoll.cs
@@ -34,7 +34,9 @@ public class DiceRoll : MonoBehaviour
 
 
     [Header("Sliding")]
-    [SerializeField] float releaseMultiplier = 480f;
+    [SerializeField] float releaseMultiplier = 12f;
+    [SerializeField] float throwMultiplier = 36f;
+    [SerializeField] float lowSpeedThreshold = 0.1f;
     [SerializeField, Range(0, 0.1f)] float frictionFactor = 0.002f;
 
     float slideTimer = 0f;
@@ -166,14 +168,14 @@ public class DiceRoll : MonoBehaviour
         spriteRenderer.sprite = sprites[roll - 1];
 
         // gives the dice a boost
-        if ( this.mouseDelta.magnitude <= 0.1f ) {
-            Debug.Log( this.mouseDelta );
+        if ( this.mouseDelta.magnitude <= lowSpeedThreshold ) {
+            Debug.Log( this.mouseDelta.magnitude ); // removeme when this feels good enough
             // if you're lazy and aren't shaking the die, throw it in a random direction anyway
             rb.velocity *= releaseMultiplier;
         } else {
-            rb.velocity = this.mouseDelta * releaseMultiplier;
+            rb.velocity = this.mouseDelta * throwMultiplier;
         }
-        Debug.Log( rb.velocity );
+        Debug.Log( rb.velocity ); // removeme when this feels good enough
 
         // restrict the dice's position to inside the screen bounds
         ClampDice();

--- a/GatekeeperStudyHall/Assets/Scripts/DiceRoll.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/DiceRoll.cs
@@ -166,8 +166,13 @@ public class DiceRoll : MonoBehaviour
         spriteRenderer.sprite = sprites[roll - 1];
 
         // gives the dice a boost
-        //rb.velocity *= releaseMultiplier;
-        rb.velocity = this.mouseDelta * releaseMultiplier;
+        if ( this.mouseDelta.magnitude <= 0.1f ) {
+            Debug.Log( this.mouseDelta );
+            // if you're lazy and aren't shaking the die, throw it in a random direction anyway
+            rb.velocity *= releaseMultiplier;
+        } else {
+            rb.velocity = this.mouseDelta * releaseMultiplier;
+        }
         Debug.Log( rb.velocity );
 
         // restrict the dice's position to inside the screen bounds

--- a/GatekeeperStudyHall/Assets/Scripts/DiceRoll.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/DiceRoll.cs
@@ -169,13 +169,11 @@ public class DiceRoll : MonoBehaviour
 
         // gives the dice a boost
         if ( this.mouseDelta.magnitude <= lowSpeedThreshold ) {
-            Debug.Log( this.mouseDelta.magnitude ); // removeme when this feels good enough
             // if you're lazy and aren't shaking the die, throw it in a random direction anyway
             rb.velocity *= releaseMultiplier;
         } else {
             rb.velocity = this.mouseDelta * throwMultiplier;
         }
-        Debug.Log( rb.velocity ); // removeme when this feels good enough
 
         // restrict the dice's position to inside the screen bounds
         ClampDice();

--- a/GatekeeperStudyHall/Assets/Scripts/DiceRoll.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/DiceRoll.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
@@ -33,7 +34,7 @@ public class DiceRoll : MonoBehaviour
 
 
     [Header("Sliding")]
-    [SerializeField] float releaseMultiplier = 12f;
+    [SerializeField] float releaseMultiplier = 480f;
     [SerializeField, Range(0, 0.1f)] float frictionFactor = 0.002f;
 
     float slideTimer = 0f;
@@ -53,6 +54,9 @@ public class DiceRoll : MonoBehaviour
     [HideInInspector] public event System.EventHandler<int> DoneRollingEvent;
     int roll = -1;
 
+
+    Vector2 mouseDelta;
+    Vector2 lastMousePos;
 
     void Start() {
         if (sprites.Length != 6) {
@@ -90,6 +94,9 @@ public class DiceRoll : MonoBehaviour
         {
             isHeld = true;
             shakeTimer = shakeInterval;
+            
+            // init the delta so we can actually do stuff to it
+            this.mouseDelta = new( 0f, 0f );
         }
     }
 
@@ -104,6 +111,11 @@ public class DiceRoll : MonoBehaviour
         mousePosition = Camera.main.ScreenToWorldPoint(mousePosition);
         mousePosition.z = transform.position.z;
         transform.position = mousePosition;
+
+        // update the delta
+        this.mouseDelta = ( Vector2 )mousePosition - this.lastMousePos;
+    
+        this.lastMousePos = mousePosition;
 
         // shake the dice once every `shakeInterval` seconds
         if (shakeTimer >= shakeInterval) {
@@ -154,7 +166,9 @@ public class DiceRoll : MonoBehaviour
         spriteRenderer.sprite = sprites[roll - 1];
 
         // gives the dice a boost
-        rb.velocity *= releaseMultiplier;
+        //rb.velocity *= releaseMultiplier;
+        rb.velocity = this.mouseDelta * releaseMultiplier;
+        Debug.Log( rb.velocity );
 
         // restrict the dice's position to inside the screen bounds
         ClampDice();


### PR DESCRIPTION
This pull request makes the die get thrown in the direction of mouse movement.
If there is no or negligible mouse movement, the die flies in a random direction as before.
The die's throw strength and the lower threshold for mouse movement are serialized fields, able to be tweaked in the editor.
This PR only changes DiceRoll.cs