### PR TITLE
98 callbacks instead of scheduled state

### DIFF
--- a/GatekeeperStudyHall/Assets/Scenes/CharSelectScene.unity
+++ b/GatekeeperStudyHall/Assets/Scenes/CharSelectScene.unity
@@ -132,6 +132,10 @@ PrefabInstance:
     m_TransformParent: {fileID: 164533148}
     m_Modifications:
     - target: {fileID: 4173000368655346186, guid: b1673ac7a0b6ae243811b05b94e23439, type: 3}
+      propertyPath: type
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4173000368655346186, guid: b1673ac7a0b6ae243811b05b94e23439, type: 3}
       propertyPath: cardData
       value: 
       objectReference: {fileID: 11400000, guid: b1148e97bcd5d4a4dac0725497919a04, type: 2}
@@ -390,6 +394,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 768347978}
     m_Modifications:
+    - target: {fileID: 4173000368655346186, guid: b1673ac7a0b6ae243811b05b94e23439, type: 3}
+      propertyPath: type
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4173000368655346186, guid: b1673ac7a0b6ae243811b05b94e23439, type: 3}
       propertyPath: player
       value: 
@@ -1200,6 +1208,10 @@ PrefabInstance:
     m_TransformParent: {fileID: 164533148}
     m_Modifications:
     - target: {fileID: 4173000368655346186, guid: b1673ac7a0b6ae243811b05b94e23439, type: 3}
+      propertyPath: type
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4173000368655346186, guid: b1673ac7a0b6ae243811b05b94e23439, type: 3}
       propertyPath: cardData
       value: 
       objectReference: {fileID: 11400000, guid: 97a8a00ea8b7f804fbde4b2c248af807, type: 2}
@@ -1744,6 +1756,10 @@ PrefabInstance:
       value: 49.373
       objectReference: {fileID: 0}
     - target: {fileID: 4173000368655346186, guid: b1673ac7a0b6ae243811b05b94e23439, type: 3}
+      propertyPath: type
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4173000368655346186, guid: b1673ac7a0b6ae243811b05b94e23439, type: 3}
       propertyPath: player
       value: 
       objectReference: {fileID: 11400000, guid: 530b904106ea01c4e91e8e0ef8251d36, type: 2}
@@ -1864,6 +1880,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 164533148}
     m_Modifications:
+    - target: {fileID: 4173000368655346186, guid: b1673ac7a0b6ae243811b05b94e23439, type: 3}
+      propertyPath: type
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4173000368655346186, guid: b1673ac7a0b6ae243811b05b94e23439, type: 3}
       propertyPath: cardData
       value: 
@@ -2321,6 +2341,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   playerListObject: {fileID: 11400000, guid: ab9e637cbfc42da4e805bd63c82ffc2d, type: 2}
   player1: {fileID: 11400000, guid: 530b904106ea01c4e91e8e0ef8251d36, type: 2}
+  selectedCard: {fileID: 0}
 --- !u!1001 &735981607
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2329,6 +2350,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 164533148}
     m_Modifications:
+    - target: {fileID: 4173000368655346186, guid: b1673ac7a0b6ae243811b05b94e23439, type: 3}
+      propertyPath: type
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 4173000368655346186, guid: b1673ac7a0b6ae243811b05b94e23439, type: 3}
       propertyPath: cardData
       value: 
@@ -2629,6 +2654,10 @@ PrefabInstance:
     m_TransformParent: {fileID: 1793134940}
     m_Modifications:
     - target: {fileID: 4173000368655346186, guid: b1673ac7a0b6ae243811b05b94e23439, type: 3}
+      propertyPath: type
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4173000368655346186, guid: b1673ac7a0b6ae243811b05b94e23439, type: 3}
       propertyPath: player
       value: 
       objectReference: {fileID: 11400000, guid: cbf5a54e4c1703c4f95eecfcb3285be4, type: 2}
@@ -2750,6 +2779,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 164533148}
     m_Modifications:
+    - target: {fileID: 4173000368655346186, guid: b1673ac7a0b6ae243811b05b94e23439, type: 3}
+      propertyPath: type
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 4173000368655346186, guid: b1673ac7a0b6ae243811b05b94e23439, type: 3}
       propertyPath: cardData
       value: 
@@ -3575,6 +3608,10 @@ PrefabInstance:
     m_TransformParent: {fileID: 164533148}
     m_Modifications:
     - target: {fileID: 4173000368655346186, guid: b1673ac7a0b6ae243811b05b94e23439, type: 3}
+      propertyPath: type
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4173000368655346186, guid: b1673ac7a0b6ae243811b05b94e23439, type: 3}
       propertyPath: cardData
       value: 
       objectReference: {fileID: 11400000, guid: 72169a04f50915744b8c612bc8b2ab17, type: 2}
@@ -3835,6 +3872,10 @@ PrefabInstance:
     m_TransformParent: {fileID: 164533148}
     m_Modifications:
     - target: {fileID: 4173000368655346186, guid: b1673ac7a0b6ae243811b05b94e23439, type: 3}
+      propertyPath: type
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4173000368655346186, guid: b1673ac7a0b6ae243811b05b94e23439, type: 3}
       propertyPath: cardData
       value: 
       objectReference: {fileID: 11400000, guid: 4892601165fcc284ba39f75bfef40d1d, type: 2}
@@ -3960,6 +4001,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 240308201}
     m_Modifications:
+    - target: {fileID: 4173000368655346186, guid: b1673ac7a0b6ae243811b05b94e23439, type: 3}
+      propertyPath: type
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4173000368655346186, guid: b1673ac7a0b6ae243811b05b94e23439, type: 3}
       propertyPath: player
       value: 

--- a/GatekeeperStudyHall/Assets/Scenes/GkScene.unity
+++ b/GatekeeperStudyHall/Assets/Scenes/GkScene.unity
@@ -1007,6 +1007,10 @@ PrefabInstance:
       propertyPath: choosingCardState.playerSelect
       value: 
       objectReference: {fileID: 391084954}
+    - target: {fileID: 1430531344522203847, guid: 30bd3cc3706cd6f489ded94e9157af34, type: 3}
+      propertyPath: choosingPlayerState.playerSelect
+      value: 
+      objectReference: {fileID: 391084954}
     - target: {fileID: 3649130508021954605, guid: 30bd3cc3706cd6f489ded94e9157af34, type: 3}
       propertyPath: diceRoll
       value: 

--- a/GatekeeperStudyHall/Assets/Scripts/CharSelectManager.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/CharSelectManager.cs
@@ -4,19 +4,17 @@ using UnityEngine;
 
 public class CharSelectManager : MonoBehaviour
 {
-    
     [SerializeField] PlayerListSO playerListObject;
     List<PlayerSO> playerList; // refers to list in playerListObject
     
     [SerializeField] PlayerSO player1;
 
+    public CardSO selectedCard;
 
-    // Awake is called as soon as the object is created
     private void Start() 
     {
         playerList = playerListObject.list;
         playerList.Clear();
         playerList.Add(player1);
     }
-
 }

--- a/GatekeeperStudyHall/Assets/Scripts/Globals.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/Globals.cs
@@ -13,16 +13,4 @@ public static class Globals
     /// Holds <c>null</c> if the player has not yet chosen a gate or has already attacked a gate.
     /// </summary>
     public static GateSO selectedGate = null;
-
-    /// <summary>
-    /// The character card that the current player has selected.
-    /// Holds <c>null</c> if no card has been selected or if we no longer need a reference to the selected card.
-    /// </summary>
-    public static CardSO selectedCard = null;
-
-    /// <summary>
-    ///   <para>The state that we want to enter after we exit the current state. </para>
-    ///   <para>This field is useful when it would otherwise not be clear what state the <see cref="StateMachine" /> should transition to.  </para>
-    /// </summary>
-    public static IState scheduledState = null;
 }

--- a/GatekeeperStudyHall/Assets/Scripts/PlayerSelection.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/PlayerSelection.cs
@@ -2,10 +2,14 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.Assertions;
 
 public class PlayerSelection : MonoBehaviour
 {
+    /// <summary>
+    /// When a player is selected, this function is called with the chosen player as the argument.
+    /// </summary>
+    public Action<PlayerSO> OnSelect;
+
     [SerializeField] PlayerListSO playerListSO;
     [SerializeField] GameObject cardDisplayPrefab;
     [SerializeField] StateMachine stateMachine;
@@ -54,7 +58,9 @@ public class PlayerSelection : MonoBehaviour
 
         for (int i = 0; i < displayObjects.Count; i++)
         {
-            displayObjects[i].GetComponent<CardDisplay>().ChangeCardData(playerList[i+1].card);
+            CardDisplay cardDisplay = displayObjects[i].GetComponent<CardDisplay>();
+            cardDisplay.player = playerList[i + 1];
+            cardDisplay.ChangeCardData(playerList[i + 1].card);
         }
 
         Reposition();
@@ -65,14 +71,9 @@ public class PlayerSelection : MonoBehaviour
     void CreateDisplayObject()
     {
         GameObject cardObject = Instantiate(cardDisplayPrefab, panel);
-        CardDisplay display = cardObject.GetComponent<CardDisplay>();
-
-        // all these cards are selectable, and when they are selected,
-        // they should exit the "select card" state and enter the next one
-        display.isSelectable = true;
-        display.OnSelect.AddListener(TransitionToScheduled);
-
         displayObjects.Add(cardObject);
+
+        cardObject.GetComponent<CardDisplay>().type = CardDisplayType.PLAYER_SELECT_OPTION;
     }
 
 
@@ -81,20 +82,6 @@ public class PlayerSelection : MonoBehaviour
         GameObject obj = displayObjects[displayObjects.Count - 1];
         displayObjects.RemoveAt(displayObjects.Count - 1);
         Destroy(obj);
-    }
-
-
-    /// <summary>
-    /// Transitions to the <see cref="Globals.scheduledState">scheduled state</see>
-    /// stored statically in Globals, and resets its value to null. 
-    /// </summary>
-    void TransitionToScheduled()
-    {
-        Assert.IsNotNull(Globals.scheduledState, "The scheduled state must have a non-null value at this point.");
-
-        IState state = Globals.scheduledState;
-        Globals.scheduledState = null;
-        stateMachine.TransitionTo(state);
     }
 
 

--- a/GatekeeperStudyHall/Assets/Scripts/StateMachine.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/StateMachine.cs
@@ -17,7 +17,7 @@ public class StateMachine : MonoBehaviour
     public ChoosingGateState choosingGateState;
     public AttackingGateState attackingGateState;
     public BreakingGateState breakingGateState;
-    public ChoosingCardState choosingCardState;
+    public ChoosingPlayerState choosingPlayerState;
 
     /// <summary>
     /// This C# event is triggered whenever the state changes.

--- a/GatekeeperStudyHall/Assets/Scripts/States.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/States.cs
@@ -88,7 +88,7 @@ public class BreakingGateState : IState
 /// The state where the game waits for the current player to choose a card for a trait, a battle, or a gate effect.
 /// </summary>
 [Serializable]
-public class ChoosingCardState : IState
+public class ChoosingPlayerState : IState
 {
     [SerializeField] PlayerSelection playerSelect;
 

--- a/GatekeeperStudyHall/Assets/Scripts/VisualScripts/CardDisplay.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/VisualScripts/CardDisplay.cs
@@ -73,7 +73,10 @@ public class CardDisplay : MonoBehaviour, IPointerEnterHandler, IPointerExitHand
 
                 case CardDisplayType.PLAYER_SELECT_OPTION:
                     Debug.Log("Card selected: " + cardData.characterName);
+                    Assert.IsNotNull(playerSelection.OnSelect, "The OnSelect callback must have a value at this point");
+
                     playerSelection.OnSelect(player);
+                    playerSelection.OnSelect = null;
                     break;
             }
         }

--- a/GatekeeperStudyHall/Assets/Scripts/VisualScripts/CardQueue.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/VisualScripts/CardQueue.cs
@@ -92,13 +92,11 @@ public class CardQueue : MonoBehaviour
             CardDisplay cardDisplay = cardTransform.GetComponent<CardDisplay>();
             cardTransform.localPosition = offset;
 
-            HealthDisplay healthDisplay = healthBarList[i].GetComponent<HealthDisplay>();
+            cardDisplay.ChangeCardData(playerList[i].card);
+            cardDisplay.player = playerList[i];
 
-            if (playerList[i].card != cardDisplay.cardData) 
-            {
-                cardDisplay.ChangeCardData(playerList[i].card);
-                healthDisplay.player = playerList[i];
-            }
+            HealthDisplay healthDisplay = healthBarList[i].GetComponent<HealthDisplay>();
+            healthDisplay.player = playerList[i];
 
             if (i == expandedIndex) 
             {


### PR DESCRIPTION
- CharSelectManager now stores the selected card for the character select menu
- PlayerSelection now has a callback OnSelect that is called when a player is selected
- removed the global "selected state" and "chosen card"
- gave the CardDisplay a CardDisplayType enum to replace a bunch of mutually exclusive booleans
- made necessary fixes in the editor

Closes #98