### PR TITLE
106 clamp player health

### DIFF
--- a/GatekeeperStudyHall/Assets/ScriptableObjects/CenterGateSO.cs
+++ b/GatekeeperStudyHall/Assets/ScriptableObjects/CenterGateSO.cs
@@ -8,14 +8,31 @@ using UnityEngine;
 [CreateAssetMenu(fileName = "New_CenterGateSO", menuName = "Scriptable Objects/CenterGateSO")]
 public class CenterGateSO : ScriptableObject
 {
-    public const int MAX_HEALTH = 10;
-    public int health = MAX_HEALTH;
+    const int MAX_HEALTH = 10;
+    const int STARTING_HEALTH = 10;
+    
+    public int Health => health;
+    [SerializeField] int health = STARTING_HEALTH;
     
     void OnEnable() {
-        health = MAX_HEALTH;
+        health = STARTING_HEALTH;
     }
 
     public override string ToString() {
         return $"CenterGateSO[health=\"{health}\"]";
+    }
+    
+    public void TakeDamage(int damage)
+    {
+        if (damage <= 0) return;
+        
+        health = Mathf.Max(0, health - damage);
+    }
+
+    public void Heal(int amount)
+    {
+        if (amount <= 0) return;
+        
+        health = Mathf.Min(health + amount, MAX_HEALTH);
     }
 }

--- a/GatekeeperStudyHall/Assets/ScriptableObjects/GateSO.cs
+++ b/GatekeeperStudyHall/Assets/ScriptableObjects/GateSO.cs
@@ -9,18 +9,19 @@ public enum GateColor
 
 
 /// <summary>
-/// Represents a gate with its color and health.
+/// Represents a gate with its color and health. Provides methods to take damage, heal, and reset after breaking.
 /// </summary>
 [CreateAssetMenu(fileName = "New_GateSO", menuName = "Scriptable Objects/GateSO")]
 public class GateSO : ScriptableObject
 {
-    public const int STARTING_HEALTH = 6;
-    public const int MAX_HEALTH = 6;
+    const int STARTING_HEALTH = 6;
+    const int MAX_HEALTH = 6;
 
-    public GateColor Color { get => color; }
+    public GateColor Color => color;
     [SerializeField] GateColor color;
 
-    public int health = STARTING_HEALTH;
+    public int Health => health;
+    [SerializeField] int health = STARTING_HEALTH;
     
     
     void OnEnable() 
@@ -30,5 +31,24 @@ public class GateSO : ScriptableObject
 
     public override string ToString() {
         return $"GateSO[health=\"{health}\", color=\"{color}\"]";
+    }
+
+    public void TakeDamage(int damage)
+    {
+        if (damage <= 0) return;
+        
+        health = Mathf.Max(0, health - damage);
+    }
+
+    public void Heal(int amount)
+    {
+        if (amount <= 0) return;
+        
+        health = Mathf.Min(health + amount, MAX_HEALTH);
+    }
+
+    public void Reset()
+    {
+        health = STARTING_HEALTH;
     }
 }

--- a/GatekeeperStudyHall/Assets/ScriptableObjects/PlayerSO.cs
+++ b/GatekeeperStudyHall/Assets/ScriptableObjects/PlayerSO.cs
@@ -11,9 +11,11 @@ public class PlayerSO : ScriptableObject
     // These are regular fields so that we can inspect them in the editor.
     // Using a boolean for the stockade because it doesn't seem like we'll use the multiple stockade rule.
     public CardSO card;
-    public int health;
     public bool hasStockade;
-
+    
+    public int Health => health; // makes Health readonly in other scripts
+    [SerializeField] int health; // makes health visible from inspector
+    
     public bool isAlive; 
 
     // not final
@@ -49,5 +51,35 @@ public class PlayerSO : ScriptableObject
         reduceGateDamage = 0;
         doubleGateAbil = 1;
         doubleDamageToSelf = 1;
+    }
+
+    public void TakeDamage(int damage)
+    {
+        if (damage <= 0) return;
+        if (noDamageTurn) {
+            Debug.Log($"{name} takes no damage this turn!");
+            return;
+        }
+        if (hasStockade) {
+            hasStockade = false;
+            Debug.Log("Stockade blocked the attack!");
+            return;
+        }
+        
+        health -= damage;
+        
+        if (health <= 0)
+        {
+            health = 0;
+            isAlive = false;
+            Globals.playersAlive--;
+        }
+    }
+
+    public void Heal(int amount)
+    {
+        if (amount <= 0) return;
+        
+        health = Mathf.Min(health + amount, MAX_HEALTH);
     }
 }

--- a/GatekeeperStudyHall/Assets/ScriptableObjects/PlayerSO.cs
+++ b/GatekeeperStudyHall/Assets/ScriptableObjects/PlayerSO.cs
@@ -44,7 +44,7 @@ public class PlayerSO : ScriptableObject
     /// <summary>
     /// Resets all effects that the player has.
     /// </summary>
-    public void resetEffects(){
+    public void ResetEffects(){
         doubleDamageToCenter = 1;
         noDamageTurn = false;
         increaseGateDamage = 0;

--- a/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
@@ -97,7 +97,7 @@ public class GameManager : MonoBehaviour
     /// <param name="roll">The rolled value of the dice.</param>
     private void UseRollResult(int roll) {
         PlayerSO currentPlayer = playerListSO.list[0];
-        if (stateMachine.CurrentState == stateMachine.traitRollState) 
+        if (stateMachine.CurrentState is TraitRollState) 
         {
             if (roll <= 4) 
             {
@@ -124,13 +124,12 @@ public class GameManager : MonoBehaviour
                 NextTurn();
             }
         }
-        else if (stateMachine.CurrentState == stateMachine.attackingGateState) 
+        else if (stateMachine.CurrentState is AttackingGateState) 
         {
-            bool gateIsBreaking;
             int attack = roll + currentPlayer.increaseGateDamage - currentPlayer.reduceGateDamage;
             attack = Mathf.Max(0, attack); // set to 0 if attack comes out negative
             Debug.Log($"attacking for {attack} damage");
-            gateIsBreaking = GateChangeHealth(currentPlayer, Globals.selectedGate, -attack);
+            bool gateIsBreaking = GateChangeHealth(currentPlayer, Globals.selectedGate, -attack);
          
             if (gateIsBreaking) {
                 Debug.Log("You broke the gate!");
@@ -140,7 +139,7 @@ public class GameManager : MonoBehaviour
                 NextTurn();
             }
         }
-        else if (stateMachine.CurrentState == stateMachine.breakingGateState)
+        else if (stateMachine.CurrentState is BreakingGateState)
         {
             IState nextState = gateBreak.DoBreakEffect(playerListSO.list[0], Globals.selectedGate, roll);
             Globals.selectedGate.health = GateSO.STARTING_HEALTH;
@@ -150,7 +149,7 @@ public class GameManager : MonoBehaviour
             else 
                 stateMachine.TransitionTo(nextState);
         }
-        else if ( stateMachine.CurrentState == stateMachine.battlingState ) {
+        else if ( stateMachine.CurrentState is BattlingState ) {
             if ( Globals.battleAttackerAttacking ) {
                 Globals.battleData[ 0 ] = new( Globals.battleData[ 0 ].ply, roll );
                 Globals.battleAttackerAttacking = false;
@@ -171,7 +170,7 @@ public class GameManager : MonoBehaviour
 
                     PlayerAttacksPlayer( damageDealer, damageTaker, damageDealt );
                     
-                    Debug.Log( "Battle concluded, a player should have taken " + damageDealt + ", next!" );
+                    Debug.Log($"Battle concluded, {damageTaker} should have taken {damageDealt} damage. Continue with turn...");
 
                     Globals.battleData = new();
                     Globals.bDmgTurns = 1;
@@ -198,7 +197,7 @@ public class GameManager : MonoBehaviour
 
         List<PlayerSO>players = playerListSO.list;
 
-        players[0].resetEffects(); //reset all temporary effects the current player may have
+        players[0].ResetEffects(); //reset all temporary effects the current player may have
         do {      
             players.Insert(players.Count, players[0]);
             players.RemoveAt(0);

--- a/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
@@ -32,22 +32,8 @@ public class GameManager : MonoBehaviour
     /// </summary>
     public static void PlayerAttacksPlayer(PlayerSO attacker, PlayerSO defender, int damage)
     {
-        if(defender.noDamageTurn){
-            damage = 0;
-            Debug.Log($"{defender.name} takes no damage this turn!");
-        }
-        else if(defender.hasStockade){
-            damage = 0;
-            defender.hasStockade = false;
-            Debug.Log("Stockade blocked the attack!");
-        }
-        defender.health -= damage;
+        defender.TakeDamage(damage);
         Debug.Log($"{attacker.name} attacked {defender.name} for {damage} damage!");
-
-        if (defender.health <= 0) {
-            defender.isAlive = false;
-            Globals.playersAlive--;
-        }
     }
 
 
@@ -82,27 +68,10 @@ public class GameManager : MonoBehaviour
     /// <param name="amount">The amount of health to change by (positive to heal, negative to take damage).</param>
     public static void PlayerChangeHealth(PlayerSO player, int amount)
     {
-        if(player.noDamageTurn){
-            amount = 0;
-            Debug.Log($"{player.name} takes no damage this turn!");
-        }
-        else if(amount < 0 && player.hasStockade){
-            player.hasStockade = false;
-            amount = 0;
-            Debug.Log("Stockade blocked the damage!");
-        }
-        player.health += amount;
-
-        if (player.health <= 0) 
-        {
-            player.health = 0;
-            player.isAlive = false;
-            Globals.playersAlive--;
-        }
-        else if (player.health > PlayerSO.MAX_HEALTH) 
-        {
-            player.health = PlayerSO.MAX_HEALTH;
-        }
+        if (amount < 0)
+            player.TakeDamage(-amount);
+        else
+            player.Heal(amount);
     }
 
 

--- a/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
@@ -80,14 +80,15 @@ public class GameManager : MonoBehaviour
     /// Use this method whenever a player causes a gate to change health.
     /// </summary>
     /// <param name="player">The player who caused the change.</param>
+    /// <param name="gate">The gate that is changing health.</param>
     /// <param name="amount">The amount to change by (positive to heal, negative to deal damage)</param>
     /// <returns><c>true</c> only if the gate's health has reached zero.</returns>
-    public bool GateChangeHealth(PlayerSO player, GateSO gate, int amount) 
+    public void GateChangeHealth(PlayerSO player, GateSO gate, int amount) 
     {
-        gate.health += amount;
-        gate.health = Mathf.Clamp(gate.health, 0, GateSO.MAX_HEALTH);
-
-        return gate.health == 0;
+        if (amount < 0)
+            gate.TakeDamage(-amount);
+        else 
+            gate.Heal(amount);
     }
 
 
@@ -129,9 +130,9 @@ public class GameManager : MonoBehaviour
             int attack = roll + currentPlayer.increaseGateDamage - currentPlayer.reduceGateDamage;
             attack = Mathf.Max(0, attack); // set to 0 if attack comes out negative
             Debug.Log($"attacking for {attack} damage");
-            bool gateIsBreaking = GateChangeHealth(currentPlayer, Globals.selectedGate, -attack);
+            GateChangeHealth(currentPlayer, Globals.selectedGate, -attack);
          
-            if (gateIsBreaking) {
+            if (Globals.selectedGate.Health == 0) {
                 Debug.Log("You broke the gate!");
                 stateMachine.TransitionTo(stateMachine.breakingGateState);
             }
@@ -142,7 +143,7 @@ public class GameManager : MonoBehaviour
         else if (stateMachine.CurrentState is BreakingGateState)
         {
             IState nextState = gateBreak.DoBreakEffect(playerListSO.list[0], Globals.selectedGate, roll);
-            Globals.selectedGate.health = GateSO.STARTING_HEALTH;
+            Globals.selectedGate.Reset();
             
             if (nextState == null)
                 NextTurn();

--- a/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
@@ -45,18 +45,16 @@ public class GameManager : MonoBehaviour
     /// <param name="damage"></param>
     public void PlayerAttacksCenterGate(PlayerSO attacker, int damage)
     {
-        centerGate.health = Mathf.Clamp(centerGate.health - damage, 0, CenterGateSO.MAX_HEALTH);
-        if (centerGate.health == 0)
+        centerGate.TakeDamage(damage);
+        
+        if (centerGate.Health == 0)
         {
             Debug.Log($"{attacker.card.characterName} wins! End the game here");
         }
     }
 
 
-    public void HealCenterGate(int amount)
-    {
-        centerGate.health = Mathf.Min(centerGate.health + amount, CenterGateSO.MAX_HEALTH);
-    }
+    public void HealCenterGate(int amount) => centerGate.Heal(amount);
 
 
     /// <summary>

--- a/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -165,7 +164,7 @@ public class GameManager : MonoBehaviour
                     PlayerSO damageDealer = Globals.battleData[ 0 ].roll > Globals.battleData[ 1 ].roll ? Globals.battleData[ 0 ].ply : Globals.battleData[ 1 ].ply;
                     PlayerSO damageTaker = Globals.battleData[ 0 ].roll > Globals.battleData[ 1 ].roll ? Globals.battleData[ 1 ].ply : Globals.battleData[ 0 ].ply;
 
-                    int damageDealt = Math.Abs( Globals.battleData[ 0 ].roll - Globals.battleData[ 1 ].roll ) * Globals.bDmgTurns;
+                    int damageDealt = Mathf.Abs( Globals.battleData[ 0 ].roll - Globals.battleData[ 1 ].roll ) * Globals.bDmgTurns;
 
                     PlayerAttacksPlayer( damageDealer, damageTaker, damageDealt );
                     

--- a/GatekeeperStudyHall/Assets/Scripts/VisualScripts/CenterGateDisplay.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/VisualScripts/CenterGateDisplay.cs
@@ -9,6 +9,6 @@ public class CenterGateDisplay : MonoBehaviour
 
     void Update()
     {
-        textbox.text = centerGate.health.ToString();
+        textbox.text = centerGate.Health.ToString();
     }
 }

--- a/GatekeeperStudyHall/Assets/Scripts/VisualScripts/GateDisplay.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/VisualScripts/GateDisplay.cs
@@ -9,6 +9,6 @@ public class GateDisplay : MonoBehaviour
 
     void Update()
     {
-        textbox.text = gate.health.ToString();
+        textbox.text = gate.Health.ToString();
     }
 }

--- a/GatekeeperStudyHall/Assets/Scripts/VisualScripts/HealthDisplay.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/VisualScripts/HealthDisplay.cs
@@ -29,9 +29,9 @@ public class HealthDisplay : MonoBehaviour
 
     void Update()
     {
-        float healthRatio = Mathf.Clamp(player.health, 0, PlayerSO.MAX_HEALTH) / (float)PlayerSO.MAX_HEALTH;
+        float healthRatio = Mathf.Clamp(player.Health, 0, PlayerSO.MAX_HEALTH) / (float)PlayerSO.MAX_HEALTH;
         slider.sizeDelta = new Vector2(initialWidth * healthRatio, slider.sizeDelta.y);
-        healthCounter.text = player.health.ToString();
+        healthCounter.text = player.Health.ToString();
 
         if (player.hasStockade != hadStockadeLastUpdate) 
         {

--- a/GatekeeperStudyHall/Packages/manifest.json
+++ b/GatekeeperStudyHall/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.feature.2d": "2.0.0",
-    "com.unity.ide.rider": "3.0.27",
+    "com.unity.ide.rider": "3.0.34",
     "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.test-framework": "1.1.33",
     "com.unity.textmeshpro": "3.0.6",

--- a/GatekeeperStudyHall/Packages/packages-lock.json
+++ b/GatekeeperStudyHall/Packages/packages-lock.json
@@ -18,8 +18,8 @@
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.2d.sprite": "1.0.0",
         "com.unity.2d.common": "6.0.6",
+        "com.unity.2d.sprite": "1.0.0",
         "com.unity.mathematics": "1.2.6",
         "com.unity.modules.animation": "1.0.0"
       },
@@ -30,11 +30,11 @@
       "depth": 2,
       "source": "registry",
       "dependencies": {
+        "com.unity.burst": "1.7.3",
         "com.unity.2d.sprite": "1.0.0",
         "com.unity.mathematics": "1.1.0",
-        "com.unity.modules.uielements": "1.0.0",
         "com.unity.modules.animation": "1.0.0",
-        "com.unity.burst": "1.7.3"
+        "com.unity.modules.uielements": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },
@@ -50,9 +50,9 @@
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.2d.animation": "9.1.0",
         "com.unity.2d.common": "8.0.2",
-        "com.unity.2d.sprite": "1.0.0"
+        "com.unity.2d.sprite": "1.0.0",
+        "com.unity.2d.animation": "9.1.0"
       },
       "url": "https://packages.unity.com"
     },
@@ -67,8 +67,8 @@
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.mathematics": "1.1.0",
         "com.unity.2d.common": "8.0.1",
+        "com.unity.mathematics": "1.1.0",
         "com.unity.modules.physics2d": "1.0.0"
       },
       "url": "https://packages.unity.com"
@@ -87,9 +87,9 @@
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.modules.tilemap": "1.0.0",
-        "com.unity.2d.tilemap": "1.0.0",
         "com.unity.ugui": "1.0.0",
+        "com.unity.2d.tilemap": "1.0.0",
+        "com.unity.modules.tilemap": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
       },
       "url": "https://packages.unity.com"
@@ -137,7 +137,7 @@
       }
     },
     "com.unity.ide.rider": {
-      "version": "3.0.27",
+      "version": "3.0.34",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -186,9 +186,9 @@
       "depth": 0,
       "source": "registry",
       "dependencies": {
+        "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.director": "1.0.0",
         "com.unity.modules.animation": "1.0.0",
-        "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.particlesystem": "1.0.0"
       },
       "url": "https://packages.unity.com"


### PR DESCRIPTION
Fixed issue where player health can go negative by only allowing outside code to change the health through Heal and TakeDamage methods, which always clamp the health

Also implemented this for the outer gates and the center gate

Did some extra code cleanup too, and updated the unity rider package (it was being annoying)

closes #106 