### PR TITLE
107 store game stats

### DIFF
--- a/GatekeeperStudyHall/Assets/Scenes/EndScene.unity
+++ b/GatekeeperStudyHall/Assets/Scenes/EndScene.unity
@@ -390,6 +390,50 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 625114996}
   m_CullTransparentMesh: 1
+--- !u!1 &818767938
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 818767940}
+  - component: {fileID: 818767939}
+  m_Layer: 0
+  m_Name: WinnerText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &818767939
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 818767938}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d930cf2753bcd5648949c25ab80a0e13, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &818767940
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 818767938}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.9906251, y: 0.48256084, z: 5.568381}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &829913146
 GameObject:
   m_ObjectHideFlags: 0
@@ -839,3 +883,4 @@ SceneRoots:
   - {fileID: 829913149}
   - {fileID: 1621433382}
   - {fileID: 873923559}
+  - {fileID: 818767940}

--- a/GatekeeperStudyHall/Assets/Scenes/GkScene.unity
+++ b/GatekeeperStudyHall/Assets/Scenes/GkScene.unity
@@ -2157,6 +2157,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3346e94a9ee221f4a8c66b42f0783a24, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  gameManager: {fileID: 413017099}
   stateMachine: {fileID: 1085388489}
   playerSelection: {fileID: 391084954}
   playerListObject: {fileID: 11400000, guid: ab9e637cbfc42da4e805bd63c82ffc2d, type: 2}

--- a/GatekeeperStudyHall/Assets/ScriptableObjects/PlayerSO.cs
+++ b/GatekeeperStudyHall/Assets/ScriptableObjects/PlayerSO.cs
@@ -32,6 +32,7 @@ public class PlayerSO : ScriptableObject
     public int totalDamageToGatekeeper;
     public int totalAmountHealed; // Total health healed during the game
     public int totalStockade; // Total amount of stockade collected during the game
+    public int battlesStarted; // Total number of battles started
 
     // when this SO is loaded into a scene, reset values that may have been changed
     private void OnEnable() {
@@ -40,14 +41,28 @@ public class PlayerSO : ScriptableObject
 
         isAlive = true;
   
+        // Initialize Trait Variables
         doubleDamageToCenter = 1;
         noDamageTurn = false;
         reduceGateDamage = 0;
         increaseGateDamage = 0;
         doubleGateAbil = 1;
         doubleDamageToSelf = 1;
+
+        // Initialize Statistic Variables
+        totalDamageToOtherPlayers = 0;
+        totalDamageToGates = 0;
+        totalDamageToGatekeeper = 0;
+        totalAmountHealed = 0;
+        totalStockade = 0;
+        battlesStarted = 0;
     }
 
+    /// <summary>
+    /// This function should only be used to reset a player at the start of a new game.
+    /// It resets the player's health, stockade status and all statistics variables.
+    /// Make sure it is called for each player in the player list.
+    /// </summary>
     public void GameReset() {
 
         health = STARTING_HEALTH;
@@ -61,6 +76,8 @@ public class PlayerSO : ScriptableObject
         totalDamageToGatekeeper = 0;
         totalAmountHealed = 0;
         totalStockade = 0;
+        battlesStarted = 0;
+        
     }
 
     /// <summary>

--- a/GatekeeperStudyHall/Assets/ScriptableObjects/PlayerSO.cs
+++ b/GatekeeperStudyHall/Assets/ScriptableObjects/PlayerSO.cs
@@ -18,7 +18,7 @@ public class PlayerSO : ScriptableObject
     
     public bool isAlive; 
 
-    // not final
+    // Trait variables
     public int doubleDamageToCenter; // Player deals double damage to center this turn  (Multiplier)
     public int doubleDamageToSelf; // Player deals double damage to self this turn      (Multiplier)
     public int reduceGateDamage; // Player deals less damage to gate this turn
@@ -53,6 +53,10 @@ public class PlayerSO : ScriptableObject
         doubleDamageToSelf = 1;
     }
 
+    /// <summary>
+    /// Player's health is subtracted by damage parameter. 
+    /// </summary>
+    /// <param name="damage"></param>
     public void TakeDamage(int damage)
     {
         if (damage <= 0) return;
@@ -74,8 +78,12 @@ public class PlayerSO : ScriptableObject
             isAlive = false;
             Globals.playersAlive--;
         }
+        
     }
-
+    /// <summary>
+    /// Player's health is increased by the given amount.
+    /// </summary>
+    /// <param name="amount"></param>
     public void Heal(int amount)
     {
         if (amount <= 0) return;

--- a/GatekeeperStudyHall/Assets/ScriptableObjects/PlayerSO.cs
+++ b/GatekeeperStudyHall/Assets/ScriptableObjects/PlayerSO.cs
@@ -31,6 +31,7 @@ public class PlayerSO : ScriptableObject
     public int totalDamageToGates;
     public int totalDamageToGatekeeper;
     public int totalAmountHealed; // Total health healed during the game
+    public int totalDamageTaken; // Total damage taken during the game
     public int totalStockade; // Total amount of stockade collected during the game
     public int battlesStarted; // Total number of battles started
 
@@ -50,10 +51,11 @@ public class PlayerSO : ScriptableObject
         doubleDamageToSelf = 1;
 
         // Initialize Statistic Variables
-        totalDamageToOtherPlayers = 0;
+        totalDamageToOtherPlayers = 0; 
         totalDamageToGates = 0;
         totalDamageToGatekeeper = 0;
         totalAmountHealed = 0;
+        totalDamageTaken = 0;
         totalStockade = 0;
         battlesStarted = 0;
     }
@@ -75,6 +77,7 @@ public class PlayerSO : ScriptableObject
         totalDamageToGates = 0;
         totalDamageToGatekeeper = 0;
         totalAmountHealed = 0;
+        totalDamageTaken = 0;
         totalStockade = 0;
         battlesStarted = 0;
         
@@ -110,6 +113,7 @@ public class PlayerSO : ScriptableObject
         }
         
         health -= damage;
+        totalDamageTaken += damage;
         
         if (health <= 0)
         {
@@ -128,5 +132,6 @@ public class PlayerSO : ScriptableObject
         if (amount <= 0) return;
         
         health = Mathf.Min(health + amount, MAX_HEALTH);
+        totalAmountHealed += amount;
     }
 }

--- a/GatekeeperStudyHall/Assets/ScriptableObjects/PlayerSO.cs
+++ b/GatekeeperStudyHall/Assets/ScriptableObjects/PlayerSO.cs
@@ -26,6 +26,13 @@ public class PlayerSO : ScriptableObject
     public bool noDamageTurn; // Player takes no damage this turn
     public int doubleGateAbil; // Gate abilities double this turn                       (Multiplier)
 
+    // Statistic variables
+    public int totalDamageToOtherPlayers; // Total damage dealt to other players
+    public int totalDamageToGates;
+    public int totalDamageToGatekeeper;
+    public int totalAmountHealed; // Total health healed during the game
+    public int totalStockade; // Total amount of stockade collected during the game
+
     // when this SO is loaded into a scene, reset values that may have been changed
     private void OnEnable() {
         health = STARTING_HEALTH;

--- a/GatekeeperStudyHall/Assets/ScriptableObjects/PlayerSO.cs
+++ b/GatekeeperStudyHall/Assets/ScriptableObjects/PlayerSO.cs
@@ -48,6 +48,21 @@ public class PlayerSO : ScriptableObject
         doubleDamageToSelf = 1;
     }
 
+    public void GameReset() {
+
+        health = STARTING_HEALTH;
+        hasStockade = false;
+
+        isAlive = true;
+
+        // Reset all statistics
+        totalDamageToOtherPlayers = 0;
+        totalDamageToGates = 0;
+        totalDamageToGatekeeper = 0;
+        totalAmountHealed = 0;
+        totalStockade = 0;
+    }
+
     /// <summary>
     /// Resets all effects that the player has.
     /// </summary>

--- a/GatekeeperStudyHall/Assets/Scripts/ButtonScripts/CharSelectMenuOnclick.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/ButtonScripts/CharSelectMenuOnclick.cs
@@ -11,16 +11,17 @@ public class CharSelectMenuOnClick : MonoBehaviour
     void Start() 
     {
         players = playerListObject.list;
+        
+    }
+
+    public void StartGame()
+    {
         //reset players
         for(int i = 0; i < players.Count; i++)
         {
             players[i].GameReset();
             players[i].ResetEffects();
         }
-    }
-
-    public void StartGame()
-    {
         AsyncOperation _ = SceneManager.LoadSceneAsync("GkScene");
     }
     public void StartMenu()

--- a/GatekeeperStudyHall/Assets/Scripts/ButtonScripts/CharSelectMenuOnclick.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/ButtonScripts/CharSelectMenuOnclick.cs
@@ -11,6 +11,12 @@ public class CharSelectMenuOnClick : MonoBehaviour
     void Start() 
     {
         players = playerListObject.list;
+        //reset players
+        for(int i = 0; i < players.Count; i++)
+        {
+            players[i].GameReset();
+            players[i].ResetEffects();
+        }
     }
 
     public void StartGame()

--- a/GatekeeperStudyHall/Assets/Scripts/EndSceneInfo.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/EndSceneInfo.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class EndSceneInfo : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        Debug.Log($"{Globals.winningPlayer} won the game!");
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/GatekeeperStudyHall/Assets/Scripts/EndSceneInfo.cs.meta
+++ b/GatekeeperStudyHall/Assets/Scripts/EndSceneInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d930cf2753bcd5648949c25ab80a0e13
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
@@ -54,11 +54,12 @@ public class GameManager : MonoBehaviour
     public void PlayerAttacksPlayer(PlayerSO attacker, PlayerSO defender, int damage)
     {
         defender.TakeDamage(damage);
+        attacker.totalDamageToOtherPlayers +=  damage;
         Debug.Log($"{attacker.name} attacked {defender.name} for {damage} damage!");
         CheckWinBySurvival();
     }
 
-
+   
     /// <summary>
     /// <para>Reduces the health of the center gate.</para>
     /// <para>If the center gate's health is reduced to zero, the game ends.</para>
@@ -68,7 +69,7 @@ public class GameManager : MonoBehaviour
     public void PlayerAttacksCenterGate(PlayerSO attacker, int damage)
     {
         centerGate.TakeDamage(damage);
-        attacker.totalDamageToGates += damage;
+        attacker.totalDamageToGatekeeper += damage;
         if (centerGate.Health == 0)
         {
             //Debug.Log($"{attacker.card.characterName} wins! End the game here");

--- a/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 /// <summary>
 /// Provides methods for actions related to health, damage, and turn flow.
@@ -25,14 +26,36 @@ public class GameManager : MonoBehaviour
     void OnEnable() => diceRoll.DoneRollingEvent += RollEventHandler;
     void OnDestroy() => diceRoll.DoneRollingEvent -= RollEventHandler;
 
+    /// <summary>
+    /// Determine whether there is a single player alive.
+    /// The last player standing wins the game. 
+    /// </summary>
+    public void CheckWinBySurvival()
+    {
+        if (Globals.playersAlive == 1) {
+            // Determine the last player alive
+            List<PlayerSO> playerList = playerListSO.list;
+            foreach(PlayerSO player in playerList){
+                if (player.isAlive) {
+                    Globals.winningPlayer = player;  
+                    break;
+                }
+            }
+            
+            // Transition to End Scene
+            AsyncOperation _ = SceneManager.LoadSceneAsync("EndScene");
+
+        }
+    }
 
     /// <summary>
     /// Plays out the effects of one player attacking another player.
     /// </summary>
-    public static void PlayerAttacksPlayer(PlayerSO attacker, PlayerSO defender, int damage)
+    public void PlayerAttacksPlayer(PlayerSO attacker, PlayerSO defender, int damage)
     {
         defender.TakeDamage(damage);
         Debug.Log($"{attacker.name} attacked {defender.name} for {damage} damage!");
+        CheckWinBySurvival();
     }
 
 
@@ -63,10 +86,14 @@ public class GameManager : MonoBehaviour
     /// </summary>
     /// <param name="player">The player whose health changes.</param>
     /// <param name="amount">The amount of health to change by (positive to heal, negative to take damage).</param>
-    public static void PlayerChangeHealth(PlayerSO player, int amount)
+    public void PlayerChangeHealth(PlayerSO player, int amount)
     {
         if (amount < 0)
+        {
             player.TakeDamage(-amount);
+            CheckWinBySurvival();
+        }
+            
         else
             player.Heal(amount);
     }

--- a/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
@@ -71,7 +71,9 @@ public class GameManager : MonoBehaviour
         
         if (centerGate.Health == 0)
         {
-            Debug.Log($"{attacker.card.characterName} wins! End the game here");
+            //Debug.Log($"{attacker.card.characterName} wins! End the game here");
+            Globals.winningPlayer = attacker;
+            SceneManager.LoadScene("EndScene");
         }
     }
 

--- a/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
@@ -196,7 +196,7 @@ public class GameManager : MonoBehaviour
                     // a player takes damage
                     bool attackerDealsDamage = Globals.BattleData.data[ 0 ].roll > Globals.BattleData.data[ 1 ].roll;
                     PlayerSO damageDealer = attackerDealsDamage ? Globals.BattleData.data[ 0 ].player : Globals.BattleData.data[ 1 ].player;
-                    PlayerSO damageTaker = attackerDealsDamage ? Globals.BattleData.data[ 1 ].player : Globals.BattleData.data[ 0 ].player;
+                    PlayerSO damageTaker  = attackerDealsDamage ? Globals.BattleData.data[ 1 ].player : Globals.BattleData.data[ 0 ].player;
 
                     int damageDealt = Mathf.Abs( Globals.BattleData.data[ 0 ].roll - Globals.BattleData.data[ 1 ].roll ) * Globals.BattleData.mult;
 
@@ -205,6 +205,10 @@ public class GameManager : MonoBehaviour
                     Debug.Log( $"Battle concluded, {damageTaker} should have taken {damageDealt} damage. Continue with turn..." );
 
                     Globals.BattleData.Reset();
+                    // If the current player died, transition to the next player
+                    if (!playerListSO.list[0].isAlive){
+                        NextTurn();
+                    }
                     stateMachine.TransitionTo( stateMachine.choosingGateState );
                 }
             }

--- a/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
@@ -68,7 +68,7 @@ public class GameManager : MonoBehaviour
     public void PlayerAttacksCenterGate(PlayerSO attacker, int damage)
     {
         centerGate.TakeDamage(damage);
-        
+        attacker.totalDamageToGates += damage;
         if (centerGate.Health == 0)
         {
             //Debug.Log($"{attacker.card.characterName} wins! End the game here");
@@ -96,8 +96,10 @@ public class GameManager : MonoBehaviour
             CheckWinBySurvival();
         }
             
-        else
+        else{
             player.Heal(amount);
+        }
+            
     }
 
 
@@ -138,6 +140,7 @@ public class GameManager : MonoBehaviour
             else if (roll == 5) 
             {
                 // Player rolls a 5, initiate battle with another player
+                currentPlayer.battlesStarted++;
                 stateMachine.TransitionTo( stateMachine.choosingPlayerState );
                 stateMachine.choosingPlayerState.playerSelect.OnSelect = ( defender ) => {
                     Debug.Log( playerListSO.list[ 0 ] );
@@ -157,7 +160,7 @@ public class GameManager : MonoBehaviour
             attack = Mathf.Max(0, attack); // set to 0 if attack comes out negative
             Debug.Log($"attacking for {attack} damage");
             GateChangeHealth(currentPlayer, Globals.selectedGate, -attack);
-         
+            currentPlayer.totalDamageToGates += attack;
             if (Globals.selectedGate.Health == 0) {
                 Debug.Log("You broke the gate!");
                 stateMachine.TransitionTo(stateMachine.breakingGateState);

--- a/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
@@ -115,7 +115,10 @@ public class GameManager : MonoBehaviour
     public void GateChangeHealth(PlayerSO player, GateSO gate, int amount) 
     {
         if (amount < 0)
+        {
             gate.TakeDamage(-amount);
+            player.totalDamageToGates += -amount;
+        }
         else 
             gate.Heal(amount);
     }
@@ -161,7 +164,6 @@ public class GameManager : MonoBehaviour
             attack = Mathf.Max(0, attack); // set to 0 if attack comes out negative
             Debug.Log($"attacking for {attack} damage");
             GateChangeHealth(currentPlayer, Globals.selectedGate, -attack);
-            currentPlayer.totalDamageToGates += attack;
             if (Globals.selectedGate.Health == 0) {
                 Debug.Log("You broke the gate!");
                 stateMachine.TransitionTo(stateMachine.breakingGateState);

--- a/GatekeeperStudyHall/Assets/Scripts/GateBreak.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/GateBreak.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 public class GateBreak : MonoBehaviour
 {
+    
     [SerializeField] PlayerListSO playerListSO;
     GameManager gameManager;
     StateMachine stateMachine;
@@ -33,13 +34,13 @@ public class GateBreak : MonoBehaviour
         {
             case GateColor.BLACK:
                 stateMachine.choosingPlayerState.playerSelect.OnSelect = (selectedPlayer) => {
-                    GameManager.PlayerAttacksPlayer(player, selectedPlayer, 4 * player.doubleGateAbil);
+                    gameManager.PlayerAttacksPlayer(player, selectedPlayer, 4 * player.doubleGateAbil);
                     gameManager.NextTurn();
                 };
                 return stateMachine.choosingPlayerState;
 
             case GateColor.GREEN:
-                GameManager.PlayerChangeHealth(player, 3 * player.doubleGateAbil);
+                gameManager.PlayerChangeHealth(player, 3 * player.doubleGateAbil);
                 break;
 
             case GateColor.RED:
@@ -60,7 +61,7 @@ public class GateBreak : MonoBehaviour
         switch (gate.Color) 
         {
             case GateColor.BLACK:
-                GameManager.PlayerChangeHealth(player, -4 * player.doubleDamageToSelf * player.doubleGateAbil);
+                gameManager.PlayerChangeHealth(player, -4 * player.doubleDamageToSelf * player.doubleGateAbil);
                 break;
 
             case GateColor.GREEN:
@@ -69,7 +70,7 @@ public class GateBreak : MonoBehaviour
 
             case GateColor.RED:
                 player.doubleDamageToSelf = 2;
-                GameManager.PlayerChangeHealth(player, -roll * player.doubleDamageToSelf * player.doubleGateAbil);
+                gameManager.PlayerChangeHealth(player, -roll * player.doubleDamageToSelf * player.doubleGateAbil);
                 break;
 
             case GateColor.BLUE:

--- a/GatekeeperStudyHall/Assets/Scripts/GateBreak.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/GateBreak.cs
@@ -50,6 +50,7 @@ public class GateBreak : MonoBehaviour
 
             case GateColor.BLUE:
                 player.hasStockade = true;
+                player.totalStockade++;
                 break;
         }
 
@@ -86,6 +87,7 @@ public class GateBreak : MonoBehaviour
                 
                 int randIndex = Random.Range(0, candidates.Count);
                 candidates[randIndex].hasStockade = true;
+                candidates[randIndex].totalStockade++;
                 break;
         }
 

--- a/GatekeeperStudyHall/Assets/Scripts/Globals.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/Globals.cs
@@ -23,5 +23,7 @@ public static class Globals
     /// <summary>
     /// The number of players still alive 
     /// </summary>
-    public static int playersAlive = -1; 
+    public static int playersAlive = -1;
+
+    public static PlayerSO winningPlayer;
 }

--- a/GatekeeperStudyHall/Assets/Scripts/TraitHandler.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/TraitHandler.cs
@@ -31,6 +31,7 @@ public enum Trait
 /// </summary>
 public class TraitHandler : MonoBehaviour
 {
+    [SerializeField] GameManager gameManager;
     [SerializeField] StateMachine stateMachine;
     [SerializeField] PlayerSelection playerSelection;
     [SerializeField] PlayerListSO playerListObject;
@@ -75,7 +76,7 @@ public class TraitHandler : MonoBehaviour
                 //Deal 3 damage to target player
                 Debug.Log("Select a player to deal 3 damage to");
                 playerSelection.OnSelect = (selectedPlayer) => {
-                    GameManager.PlayerAttacksPlayer(player, selectedPlayer, 3);
+                    gameManager.PlayerAttacksPlayer(player, selectedPlayer, 3);
                     stateMachine.TransitionTo(stateMachine.choosingGateState);
                 };
 
@@ -89,7 +90,7 @@ public class TraitHandler : MonoBehaviour
                 break;
 
             case Trait.plus1Health:
-                GameManager.PlayerChangeHealth(player, 1);
+                gameManager.PlayerChangeHealth(player, 1);
                 break;
 
             case Trait.doubleGateAbil:
@@ -101,7 +102,7 @@ public class TraitHandler : MonoBehaviour
                 //Deal 2 damage to target player
                 Debug.Log("Select a player to deal 2 damage to");
                 playerSelection.OnSelect = (selectedPlayer) => {
-                    GameManager.PlayerAttacksPlayer(player, selectedPlayer, 2);
+                    gameManager.PlayerAttacksPlayer(player, selectedPlayer, 2);
                     stateMachine.TransitionTo(stateMachine.choosingGateState);
                 };
 
@@ -128,13 +129,13 @@ public class TraitHandler : MonoBehaviour
                 break;
 
             case Trait.minus2HP:
-                GameManager.PlayerChangeHealth(player, -2); // Player loses 2 health
+                gameManager.PlayerChangeHealth(player, -2); // Player loses 2 health
                 break;
 
             case Trait.allMinus1HP:
                 // Note: the index of the current player is always 0
                 for (int i = 1; i < players.Count; i++) {
-                    GameManager.PlayerAttacksPlayer(players[0], players[i], 1); // deal 1 damage to all other players
+                    gameManager.PlayerAttacksPlayer(players[0], players[i], 1); // deal 1 damage to all other players
                 }
                 break;
 

--- a/GatekeeperStudyHall/Assets/Scripts/TraitHandler.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/TraitHandler.cs
@@ -147,6 +147,7 @@ public class TraitHandler : MonoBehaviour
 
             case Trait.plusStockade:
                 player.hasStockade = true;
+                player.totalStockade++;
                 break;
 
             default:


### PR DESCRIPTION
Created the following statistics variables in PlayerSO:

    public int totalDamageToOtherPlayers; // Total damage dealt to other players
    public int totalDamageToGates;
    public int totalDamageToGatekeeper;
    public int totalAmountHealed; // Total health healed during the game
    public int totalDamageTaken; // Total damage taken during the game
    public int totalStockade; // Total amount of stockade collected during the game
    public int battlesStarted; // Total number of battles started

These variables are updated during the game and then reset when a new game is started using the GameReset() function in PlayerSO. 

This pull request also closes #107, closes #102, and fixes #120 