### PR TITLE
145 Animate Dice After Roll

### DIFF
--- a/GatekeeperStudyHall/Assets/Scenes/GkScene.unity
+++ b/GatekeeperStudyHall/Assets/Scenes/GkScene.unity
@@ -381,11 +381,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7285366938596312741, guid: 0a14f55c547bc3643bda3ab759a7e0ce, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 6
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 7285366938596312741, guid: 0a14f55c547bc3643bda3ab759a7e0ce, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3
+      value: -5
       objectReference: {fileID: 0}
     - target: {fileID: 7285366938596312741, guid: 0a14f55c547bc3643bda3ab759a7e0ce, type: 3}
       propertyPath: m_LocalPosition.z

--- a/GatekeeperStudyHall/Assets/Scripts/DiceRoll.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/DiceRoll.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -34,8 +33,8 @@ public class DiceRoll : MonoBehaviour
 
 
     [Header("Sliding")]
-    [SerializeField] float releaseMultiplier = 12f;
-    [SerializeField] float throwMultiplier = 36f;
+    [SerializeField] float releaseSpeedMultiplier = 12f;
+    [SerializeField] float throwSpeedMultiplier = 36f;
     [SerializeField] float lowSpeedThreshold = 0.1f;
     [SerializeField, Range(0, 0.1f)] float frictionFactor = 0.002f;
     [SerializeField] float lerpFactor = 0.25f;
@@ -53,6 +52,8 @@ public class DiceRoll : MonoBehaviour
     [SerializeField] GameObject barrier;
     SpriteRenderer spriteRenderer;
     Rigidbody2D rb;
+    
+    Vector3 startPos;
 
 
     [HideInInspector] public event System.EventHandler<int> DoneRollingEvent;
@@ -63,6 +64,7 @@ public class DiceRoll : MonoBehaviour
     Vector2 lastMousePos;
 
     void Start() {
+        startPos = transform.position;
         if (sprites.Length != 6) {
             Debug.LogError($"There should be 6 sprites in DiceRoll array (actual: {sprites.Length})");
         }
@@ -86,10 +88,8 @@ public class DiceRoll : MonoBehaviour
                 DoneRollingEvent?.Invoke(this, roll);
             }
         } else {
-            // ( 10, -5 ) is the bottom-right of the board plus some padding
-            // don't really know why but coordinate systems are not my job :P
-            float x = Mathf.Lerp( transform.position.x, 10f, lerpFactor );
-            float y = Mathf.Lerp( transform.position.y, -5f, lerpFactor );
+            float x = Mathf.Lerp( transform.position.x, startPos.x, lerpFactor );
+            float y = Mathf.Lerp( transform.position.y, startPos.y, lerpFactor );
             float z = transform.position.z;
 
             // whats a quarternion
@@ -169,7 +169,7 @@ public class DiceRoll : MonoBehaviour
     /// </summary>
     public void MouseUpFunc() {
         if (isHeld)
-            ReleaseDice(Random.Range(1, 7));
+            ReleaseDice(Random.Range(0, 6) + 1);
     }
 
     
@@ -204,13 +204,14 @@ public class DiceRoll : MonoBehaviour
 
         roll = finalRoll;
         spriteRenderer.sprite = sprites[finalRoll - 1];
+            print(mouseDelta.magnitude);
         
         // gives the dice a boost
         if ( this.mouseDelta.magnitude <= lowSpeedThreshold ) {
             // if you're lazy and aren't shaking the die, throw it in a random direction anyway
-            rb.velocity *= releaseMultiplier;
+            rb.velocity = Random.insideUnitCircle * releaseSpeedMultiplier;
         } else {
-            rb.velocity = this.mouseDelta * throwMultiplier;
+            rb.velocity = this.mouseDelta * throwSpeedMultiplier;
         }
 
         // restrict the dice's position to inside the screen bounds

--- a/GatekeeperStudyHall/Assets/Scripts/DiceRoll.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/DiceRoll.cs
@@ -41,8 +41,9 @@ public class DiceRoll : MonoBehaviour
     [SerializeField] float lerpFactor = 0.25f;
 
     float slideTimer = 0f;
-    [SerializeField, Range(0f, 1.5f)] float slideDuration = 0.75f;
-
+    // this controls how long the dice is stopped after rolling
+    // it includes a brief pause before resetting, so consider that when setting the value
+    [SerializeField, Range(0f, 3f)] float slideDuration = 1.5f;
 
     [Header("Boundaries")]
     // the dice is restricted between these while sliding
@@ -85,11 +86,14 @@ public class DiceRoll : MonoBehaviour
                 DoneRollingEvent?.Invoke(this, roll);
             }
         } else {
+            // ( 10, -5 ) is the bottom-right of the board plus some padding
+            // don't really know why but coordinate systems are not my job :P
             float x = Mathf.Lerp( transform.position.x, 10f, lerpFactor );
             float y = Mathf.Lerp( transform.position.y, -5f, lerpFactor );
             float z = transform.position.z;
 
-            float r = Mathf.Lerp( spriteRenderer.transform.rotation.z, 0, lerpFactor );
+            // whats a quarternion
+            float r = Mathf.Lerp( spriteRenderer.transform.eulerAngles.z, 0f, lerpFactor );
 
             transform.position = new( x, y, z );
             spriteRenderer.transform.eulerAngles = new( 0f, 0f, r );
@@ -227,7 +231,7 @@ public class DiceRoll : MonoBehaviour
 
         ClampDice();
 
-        if ( slideTimer >= slideDuration * 2f ) {
+        if ( slideTimer >= slideDuration ) {
             CleanUpAfterRoll();
             return true;
         }
@@ -244,8 +248,6 @@ public class DiceRoll : MonoBehaviour
 
         // shift this transform to be directly under the dice sprite's transform
         transform.position = rb.transform.position;
-        // 10, -5
-
 
         rb.transform.localPosition = Vector2.zero;
 

--- a/GatekeeperStudyHall/Assets/Scripts/DiceRoll.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/DiceRoll.cs
@@ -130,8 +130,6 @@ public class DiceRoll : MonoBehaviour
 
         // update the delta
         this.mouseDelta = ( Vector2 )mousePosition - this.lastMousePos;
-    
-        this.lastMousePos = mousePosition;
 
         // shake the dice once every `shakeInterval` seconds
         if (shakeTimer >= shakeInterval) {
@@ -161,6 +159,8 @@ public class DiceRoll : MonoBehaviour
 
         // tick the timer
         shakeTimer += Time.deltaTime;
+    
+        this.lastMousePos = mousePosition;
     }
 
 
@@ -204,7 +204,6 @@ public class DiceRoll : MonoBehaviour
 
         roll = finalRoll;
         spriteRenderer.sprite = sprites[finalRoll - 1];
-            print(mouseDelta.magnitude);
         
         // gives the dice a boost
         if ( this.mouseDelta.magnitude <= lowSpeedThreshold ) {

--- a/GatekeeperStudyHall/Assets/Scripts/DiceRoll.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/DiceRoll.cs
@@ -38,6 +38,7 @@ public class DiceRoll : MonoBehaviour
     [SerializeField] float throwMultiplier = 36f;
     [SerializeField] float lowSpeedThreshold = 0.1f;
     [SerializeField, Range(0, 0.1f)] float frictionFactor = 0.002f;
+    [SerializeField] float lerpFactor = 0.25f;
 
     float slideTimer = 0f;
     [SerializeField, Range(0f, 1.5f)] float slideDuration = 0.75f;
@@ -77,14 +78,21 @@ public class DiceRoll : MonoBehaviour
         
         if (isHeld) {
             UpdateHeldDice();
-        } 
-
-        else if (isSliding) {
+        } else if (isSliding) {
             bool isDone = UpdateSlidingDice();
 
             if (isDone) {
                 DoneRollingEvent?.Invoke(this, roll);
             }
+        } else {
+            float x = Mathf.Lerp( transform.position.x, 10f, lerpFactor );
+            float y = Mathf.Lerp( transform.position.y, -5f, lerpFactor );
+            float z = transform.position.z;
+
+            float r = Mathf.Lerp( spriteRenderer.transform.rotation.z, 0, lerpFactor );
+
+            transform.position = new( x, y, z );
+            spriteRenderer.transform.eulerAngles = new( 0f, 0f, r );
         }
     }
 
@@ -219,8 +227,7 @@ public class DiceRoll : MonoBehaviour
 
         ClampDice();
 
-        if (slideTimer >= slideDuration) 
-        {
+        if ( slideTimer >= slideDuration * 2f ) {
             CleanUpAfterRoll();
             return true;
         }
@@ -237,6 +244,9 @@ public class DiceRoll : MonoBehaviour
 
         // shift this transform to be directly under the dice sprite's transform
         transform.position = rb.transform.position;
+        // 10, -5
+
+
         rb.transform.localPosition = Vector2.zero;
 
         barrier.SetActive(false);


### PR DESCRIPTION
The dice now resets itself to the bottom-right corner after every roll.  It also starts there now instead of the general upper-right area.  The dice now also sits for twice the time (1.5s up from 0.75) to allow players time to see what was rolled before resetting.  This can be tweaked as desired.  The speed of reset can also be tweaked via a serializable field "Lerp factor".