### PR TITLE
172 Finish Unimplemented Traits

### DIFF
--- a/GatekeeperStudyHall/Assets/Scenes/GkScene.unity
+++ b/GatekeeperStudyHall/Assets/Scenes/GkScene.unity
@@ -3142,7 +3142,7 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 0.14901961, g: 0.8705883, b: 0.21176472, a: 1}
-    m_HighlightedColor: {r: 0.29546398, g: 0.94699997, b: 0.35269356, a: 1}
+    m_HighlightedColor: {r: 0.5576078, g: 0.94509804, b: 0.592622, a: 1}
     m_PressedColor: {r: 0.12574577, g: 0.7660377, b: 0.18320788, a: 1}
     m_SelectedColor: {r: 0.14901961, g: 0.8705883, b: 0.21176472, a: 1}
     m_DisabledColor: {r: 0.14901961, g: 0.8705883, b: 0.21176472, a: 0.5019608}
@@ -5573,7 +5573,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1

--- a/GatekeeperStudyHall/Assets/ScriptableObjects/CardInstances/Dynamo.asset
+++ b/GatekeeperStudyHall/Assets/ScriptableObjects/CardInstances/Dynamo.asset
@@ -26,7 +26,7 @@ MonoBehaviour:
   - Take 2 damage
   - Deal 2 damage to target player
   - Attack two gates this turn
-  traits: 0100000009000000040000000c000000
+  traits: 0100000009000000040000000d000000
   flavorText: 
   flavorTextColor: {r: 0, g: 0, b: 0, a: 1}
   outerColor: {r: 0.83921576, g: 0.121568635, b: 0.21960786, a: 1}

--- a/GatekeeperStudyHall/Assets/ScriptableObjects/CardInstances/Eldarian.asset
+++ b/GatekeeperStudyHall/Assets/ScriptableObjects/CardInstances/Eldarian.asset
@@ -26,7 +26,7 @@ MonoBehaviour:
   - Take 2 damage
   - +1 to gate attack roll
   - Target player loses turn
-  traits: 02000000090000000800000002000000
+  traits: 0200000009000000080000000f000000
   flavorText: 
   flavorTextColor: {r: 1, g: 1, b: 1, a: 1}
   outerColor: {r: 0.13725491, g: 0.38431376, b: 0.3529412, a: 1}

--- a/GatekeeperStudyHall/Assets/ScriptableObjects/CardInstances/Flipper.asset
+++ b/GatekeeperStudyHall/Assets/ScriptableObjects/CardInstances/Flipper.asset
@@ -26,7 +26,7 @@ MonoBehaviour:
   - Take 2 damage
   - Deal 1 damage to all opponents
   - Choose a gate for an opponent
-  traits: 08000000090000000a00000002000000
+  traits: 08000000090000000a0000000b000000
   flavorText: 
   flavorTextColor: {r: 0, g: 0, b: 0, a: 1}
   outerColor: {r: 0.80392164, g: 0.8196079, b: 0.91372555, a: 1}

--- a/GatekeeperStudyHall/Assets/ScriptableObjects/CardInstances/Flipper.asset
+++ b/GatekeeperStudyHall/Assets/ScriptableObjects/CardInstances/Flipper.asset
@@ -26,7 +26,7 @@ MonoBehaviour:
   - Take 2 damage
   - Deal 1 damage to all opponents
   - Choose a gate for an opponent
-  traits: 08000000090000000a0000000b000000
+  traits: 0e000000090000000a0000000b000000
   flavorText: 
   flavorTextColor: {r: 0, g: 0, b: 0, a: 1}
   outerColor: {r: 0.80392164, g: 0.8196079, b: 0.91372555, a: 1}

--- a/GatekeeperStudyHall/Assets/ScriptableObjects/CenterGateSO.cs
+++ b/GatekeeperStudyHall/Assets/ScriptableObjects/CenterGateSO.cs
@@ -22,11 +22,15 @@ public class CenterGateSO : ScriptableObject
         return $"CenterGateSO[health=\"{health}\"]";
     }
     
-    public void TakeDamage(int damage)
+    public void TakeDamageFromPlayer( int damage, PlayerSO ply )
     {
         if (damage <= 0) return;
         
-        health = Mathf.Max(0, health - damage);
+        int actualDamage = Mathf.Min( health, damage );
+
+        health -= actualDamage;
+        ply.totalDamageToGatekeeper += actualDamage;
+
     }
 
     public void Heal(int amount)

--- a/GatekeeperStudyHall/Assets/ScriptableObjects/GateSO.cs
+++ b/GatekeeperStudyHall/Assets/ScriptableObjects/GateSO.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public enum GateColor 
 {
-    BLACK = 0, GREEN = 1, RED = 2, BLUE = 3
+    INVALID = -1, BLACK = 0, GREEN = 1, RED = 2, BLUE = 3
 }
 
 
@@ -45,6 +45,10 @@ public class GateSO : ScriptableObject
         if (amount <= 0) return;
         
         health = Mathf.Min(health + amount, MAX_HEALTH);
+    }
+
+    public void SetHealth( int health ) {
+        this.health = health;
     }
 
     public void Reset()

--- a/GatekeeperStudyHall/Assets/ScriptableObjects/PlayerSO.cs
+++ b/GatekeeperStudyHall/Assets/ScriptableObjects/PlayerSO.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -111,19 +112,20 @@ public class PlayerSO : ScriptableObject
     /// Player's health is subtracted by damage parameter. 
     /// </summary>
     /// <param name="damage"></param>
-    public void TakeDamage(int damage)
+    public int TakeDamage(int damage)
     {
-        if (damage <= 0) return;
+        if (damage <= 0) return 0;
         if (noDamageTurn) {
             Debug.Log($"{name} takes no damage this turn!");
-            return;
+            return 0;
         }
         if (hasStockade) {
             hasStockade = false;
             Debug.Log("Stockade blocked the attack!");
-            return;
+            return 0;
         }
         
+        int actualDmg = Math.Min( health, damage );
         health -= damage;
         totalDamageTaken += damage;
         
@@ -133,6 +135,8 @@ public class PlayerSO : ScriptableObject
             isAlive = false;
             Globals.playersAlive--;
         }
+
+        return actualDmg;
         
     }
     /// <summary>

--- a/GatekeeperStudyHall/Assets/ScriptableObjects/PlayerSO.cs
+++ b/GatekeeperStudyHall/Assets/ScriptableObjects/PlayerSO.cs
@@ -28,6 +28,7 @@ public class PlayerSO : ScriptableObject
     public GateColor forcedGate; // Player forced to attack a gate, manually
     public bool twoGates; // Player can attack two gates
     public bool directAttack; // Player attacks gate for 1 HP
+    public bool skipMe;
 
     // Statistic variables
     public int totalDamageToOtherPlayers; // Total damage dealt to other players
@@ -55,6 +56,7 @@ public class PlayerSO : ScriptableObject
         forcedGate = GateColor.INVALID;
         twoGates = false;
         directAttack = false;
+        skipMe = false;
 
         // Initialize Statistic Variables
         totalDamageToOtherPlayers = 0; 
@@ -102,6 +104,7 @@ public class PlayerSO : ScriptableObject
         forcedGate = GateColor.INVALID;
         twoGates = false;
         directAttack = false;
+        skipMe = false;
     }
 
     /// <summary>

--- a/GatekeeperStudyHall/Assets/ScriptableObjects/PlayerSO.cs
+++ b/GatekeeperStudyHall/Assets/ScriptableObjects/PlayerSO.cs
@@ -25,6 +25,7 @@ public class PlayerSO : ScriptableObject
     public int increaseGateDamage; // Player deals more damage to gate this turn
     public bool noDamageTurn; // Player takes no damage this turn
     public int doubleGateAbil; // Gate abilities double this turn                       (Multiplier)
+    public GateColor forcedGate;
 
     // Statistic variables
     public int totalDamageToOtherPlayers; // Total damage dealt to other players
@@ -49,6 +50,7 @@ public class PlayerSO : ScriptableObject
         increaseGateDamage = 0;
         doubleGateAbil = 1;
         doubleDamageToSelf = 1;
+        forcedGate = GateColor.INVALID;
 
         // Initialize Statistic Variables
         totalDamageToOtherPlayers = 0; 
@@ -93,6 +95,7 @@ public class PlayerSO : ScriptableObject
         reduceGateDamage = 0;
         doubleGateAbil = 1;
         doubleDamageToSelf = 1;
+        forcedGate = GateColor.INVALID;
     }
 
     /// <summary>

--- a/GatekeeperStudyHall/Assets/ScriptableObjects/PlayerSO.cs
+++ b/GatekeeperStudyHall/Assets/ScriptableObjects/PlayerSO.cs
@@ -25,7 +25,8 @@ public class PlayerSO : ScriptableObject
     public int increaseGateDamage; // Player deals more damage to gate this turn
     public bool noDamageTurn; // Player takes no damage this turn
     public int doubleGateAbil; // Gate abilities double this turn                       (Multiplier)
-    public GateColor forcedGate;
+    public GateColor forcedGate; // Player forced to attack a gate, manually
+    public bool twoGates; // Player can attack two gates
 
     // Statistic variables
     public int totalDamageToOtherPlayers; // Total damage dealt to other players
@@ -51,6 +52,7 @@ public class PlayerSO : ScriptableObject
         doubleGateAbil = 1;
         doubleDamageToSelf = 1;
         forcedGate = GateColor.INVALID;
+        twoGates = false;
 
         // Initialize Statistic Variables
         totalDamageToOtherPlayers = 0; 
@@ -96,6 +98,7 @@ public class PlayerSO : ScriptableObject
         doubleGateAbil = 1;
         doubleDamageToSelf = 1;
         forcedGate = GateColor.INVALID;
+        twoGates = false;
     }
 
     /// <summary>

--- a/GatekeeperStudyHall/Assets/ScriptableObjects/PlayerSO.cs
+++ b/GatekeeperStudyHall/Assets/ScriptableObjects/PlayerSO.cs
@@ -27,6 +27,7 @@ public class PlayerSO : ScriptableObject
     public int doubleGateAbil; // Gate abilities double this turn                       (Multiplier)
     public GateColor forcedGate; // Player forced to attack a gate, manually
     public bool twoGates; // Player can attack two gates
+    public bool directAttack; // Player attacks gate for 1 HP
 
     // Statistic variables
     public int totalDamageToOtherPlayers; // Total damage dealt to other players
@@ -53,6 +54,7 @@ public class PlayerSO : ScriptableObject
         doubleDamageToSelf = 1;
         forcedGate = GateColor.INVALID;
         twoGates = false;
+        directAttack = false;
 
         // Initialize Statistic Variables
         totalDamageToOtherPlayers = 0; 
@@ -99,6 +101,7 @@ public class PlayerSO : ScriptableObject
         doubleDamageToSelf = 1;
         forcedGate = GateColor.INVALID;
         twoGates = false;
+        directAttack = false;
     }
 
     /// <summary>

--- a/GatekeeperStudyHall/Assets/Scripts/ButtonScripts/GateButtonActions.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/ButtonScripts/GateButtonActions.cs
@@ -26,6 +26,14 @@ public class GateButtonActions : MonoBehaviour
 
         Debug.Log($"Chose gate: {gate.Color}");
 
+        // player direct attack, cut short afterwards
+        if ( ply.directAttack ) {
+            gameManager.GateChangeHealth( ply, gate, -1 );
+            ply.directAttack = false;
+            gameManager.currentState = State.ChoosingGate;
+            return;
+        }
+
         // is this redundant, stupid, or both?  too tired to care right now
         if ( ( Globals.selectedGate == null && gameManager.currentState == State.SwappingGates ) || gameManager.currentState != State.SwappingGates ) {
             Globals.selectedGate = gate;

--- a/GatekeeperStudyHall/Assets/Scripts/ButtonScripts/GateButtonActions.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/ButtonScripts/GateButtonActions.cs
@@ -13,17 +13,20 @@ public class GateButtonActions : MonoBehaviour
     /// Stores the chosen gate and transitions to the next state.
     /// The game must be in a state where <c>CanChooseGate</c> is true; otherwise this does nothing.  
     /// </summary>
-    public void ChooseGate(GateSO gate) 
-    {
+    public void ChooseGate( GateSO gate ) {
         if (!gameManager.currentState.CanChooseGate()) 
             return;
 
-        if ( gameManager.iPlayerListSO.list[ 0 ].forcedGate != gate.Color && gameManager.iPlayerListSO.list[ 0 ].forcedGate != GateColor.INVALID )
+        if ( gameManager.iPlayerListSO.list[ 0 ].forcedGate != gate.Color && 
+            gameManager.iPlayerListSO.list[ 0 ].forcedGate != GateColor.INVALID &&
+            gameManager.currentState == State.ChoosingGate )
             return;
 
         Debug.Log($"Chose gate: {gate.Color}");
 
-        if ( Globals.selectedGate == null ) {
+        // is this redundant, stupid, or both?  too tired to care right now
+        if ( ( Globals.selectedGate == null && gameManager.currentState == State.SwappingGates ) || gameManager.currentState != State.SwappingGates ) {
+
             Globals.selectedGate = gate;
         } else {
             Globals.swapGate = gate;
@@ -33,19 +36,20 @@ public class GateButtonActions : MonoBehaviour
             Debug.Log( "FORCED!" );
             Globals.forcedPlayer.forcedGate = gate.Color;
             gameManager.currentState = State.ChoosingGate;
+
+            Globals.selectedGate = null;
         } else if ( gameManager.currentState == State.SwappingGates && Globals.swapGate != null && Globals.selectedGate != Globals.swapGate ) {
             int swapHP = Globals.swapGate.Health;
 
             Globals.swapGate.SetHealth( Globals.selectedGate.Health );
             Globals.selectedGate.SetHealth( swapHP );
             
+            Globals.selectedGate = null;
             Globals.swapGate = null;
             gameManager.currentState = State.ChoosingGate;
-        } else {
+        } else if ( gameManager.currentState != State.SwappingGates && Globals.swapGate == null ) {
             gameManager.currentState = State.AttackingGate;
+            gameManager.iPlayerListSO.list[ 0 ].forcedGate = GateColor.INVALID;
         }
-
-        gameManager.iPlayerListSO.list[ 0 ].forcedGate = GateColor.INVALID;
-        Globals.selectedGate = null;
     }
 }

--- a/GatekeeperStudyHall/Assets/Scripts/ButtonScripts/GateButtonActions.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/ButtonScripts/GateButtonActions.cs
@@ -18,8 +18,34 @@ public class GateButtonActions : MonoBehaviour
         if (!gameManager.currentState.CanChooseGate()) 
             return;
 
+        if ( gameManager.iPlayerListSO.list[ 0 ].forcedGate != gate.Color && gameManager.iPlayerListSO.list[ 0 ].forcedGate != GateColor.INVALID )
+            return;
+
         Debug.Log($"Chose gate: {gate.Color}");
-        Globals.selectedGate = gate;
-        gameManager.currentState = State.AttackingGate;
+
+        if ( Globals.selectedGate == null ) {
+            Globals.selectedGate = gate;
+        } else {
+            Globals.swapGate = gate;
+        }
+
+        if ( gameManager.currentState == State.ForcingGate ) {
+            Debug.Log( "FORCED!" );
+            Globals.forcedPlayer.forcedGate = gate.Color;
+            gameManager.currentState = State.ChoosingGate;
+        } else if ( gameManager.currentState == State.SwappingGates && Globals.swapGate != null && Globals.selectedGate != Globals.swapGate ) {
+            int swapHP = Globals.swapGate.Health;
+
+            Globals.swapGate.SetHealth( Globals.selectedGate.Health );
+            Globals.selectedGate.SetHealth( swapHP );
+            
+            Globals.swapGate = null;
+            gameManager.currentState = State.ChoosingGate;
+        } else {
+            gameManager.currentState = State.AttackingGate;
+        }
+
+        gameManager.iPlayerListSO.list[ 0 ].forcedGate = GateColor.INVALID;
+        Globals.selectedGate = null;
     }
 }

--- a/GatekeeperStudyHall/Assets/Scripts/ButtonScripts/GateButtonActions.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/ButtonScripts/GateButtonActions.cs
@@ -29,8 +29,12 @@ public class GateButtonActions : MonoBehaviour
         // player direct attack, cut short afterwards
         if ( ply.directAttack ) {
             gameManager.GateChangeHealth( ply, gate, -1 );
-            ply.directAttack = false;
-            gameManager.currentState = State.ChoosingGate;
+            if ( gate.Health == 0 ) {
+                Globals.selectedGate = gate;
+                Debug.Log("You broke the gate!");
+                gameManager.currentState = State.BreakingGate;
+            }
+            //gameManager.currentState = State.ChoosingGate;
             return;
         }
 

--- a/GatekeeperStudyHall/Assets/Scripts/ButtonScripts/GateButtonActions.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/ButtonScripts/GateButtonActions.cs
@@ -14,11 +14,13 @@ public class GateButtonActions : MonoBehaviour
     /// The game must be in a state where <c>CanChooseGate</c> is true; otherwise this does nothing.  
     /// </summary>
     public void ChooseGate( GateSO gate ) {
+        PlayerSO ply = gameManager.iPlayerListSO.list[ 0 ];
+
         if (!gameManager.currentState.CanChooseGate()) 
             return;
 
-        if ( gameManager.iPlayerListSO.list[ 0 ].forcedGate != gate.Color && 
-            gameManager.iPlayerListSO.list[ 0 ].forcedGate != GateColor.INVALID &&
+        if ( ply.forcedGate != gate.Color && 
+            ply.forcedGate != GateColor.INVALID &&
             gameManager.currentState == State.ChoosingGate )
             return;
 
@@ -26,7 +28,6 @@ public class GateButtonActions : MonoBehaviour
 
         // is this redundant, stupid, or both?  too tired to care right now
         if ( ( Globals.selectedGate == null && gameManager.currentState == State.SwappingGates ) || gameManager.currentState != State.SwappingGates ) {
-
             Globals.selectedGate = gate;
         } else {
             Globals.swapGate = gate;

--- a/GatekeeperStudyHall/Assets/Scripts/ButtonScripts/GateButtonActions.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/ButtonScripts/GateButtonActions.cs
@@ -29,12 +29,14 @@ public class GateButtonActions : MonoBehaviour
         // player direct attack, cut short afterwards
         if ( ply.directAttack ) {
             gameManager.GateChangeHealth( ply, gate, -1 );
+            ply.directAttack = false;
             if ( gate.Health == 0 ) {
                 Globals.selectedGate = gate;
                 Debug.Log("You broke the gate!");
                 gameManager.currentState = State.BreakingGate;
+                return;
             }
-            //gameManager.currentState = State.ChoosingGate;
+            gameManager.currentState = State.ChoosingGate;
             return;
         }
 

--- a/GatekeeperStudyHall/Assets/Scripts/DebugScripts/StateDebug.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/DebugScripts/StateDebug.cs
@@ -17,6 +17,6 @@ public class StateDebug : MonoBehaviour
     {
         textbox.text = 
             $"Current State: {gameManager.currentState}\nCan Roll: {gameManager.currentState.CanRoll()}\n" 
-            + $"Can Choose Gate: {gameManager.currentState.CanChooseGate()}\nChosen Gate: {Globals.selectedGate}";
+            + $"Can Choose Gate: {gameManager.currentState.CanChooseGate()}\nChosen Gates: {Globals.selectedGate} & {Globals.swapGate}";
     }
 }

--- a/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
@@ -14,6 +14,7 @@ public class GameManager : MonoBehaviour
     [SerializeField] GateBreak gateBreak;
 
     [SerializeField] PlayerListSO playerListSO;
+    public PlayerListSO iPlayerListSO;
     [SerializeField] CardQueue cardQueue;
 
     [SerializeField] PlayerSelection playerSelect;
@@ -30,6 +31,7 @@ public class GameManager : MonoBehaviour
     void Awake() 
     {
         // set the amount of players alive to the initial size of the player list
+        iPlayerListSO = playerListSO;
         Globals.playersAlive = playerListSO.list.Count;
     }
     
@@ -90,8 +92,7 @@ public class GameManager : MonoBehaviour
     /// <param name="damage"></param>
     public void PlayerAttacksCenterGate(PlayerSO attacker, int damage)
     {
-        centerGate.TakeDamage(damage);
-        attacker.totalDamageToGatekeeper += damage;
+        centerGate.TakeDamageFromPlayer( damage, attacker );
         if (centerGate.Health == 0)
         {
             Globals.winningPlayer = attacker;

--- a/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
@@ -31,7 +31,7 @@ public class GameManager : MonoBehaviour
     void Awake() 
     {
         // set the amount of players alive to the initial size of the player list
-        iPlayerListSO = playerListSO;
+        iPlayerListSO = playerListSO; // this is dumb but i think it works
         Globals.playersAlive = playerListSO.list.Count;
     }
     

--- a/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
@@ -77,10 +77,12 @@ public class GameManager : MonoBehaviour
     /// </summary>
     public void PlayerAttacksPlayer(PlayerSO attacker, PlayerSO defender, int damage)
     {
-        defender.TakeDamage(damage);
-        attacker.totalDamageToOtherPlayers +=  damage;
-        Debug.Log($"{attacker.name} attacked {defender.name} for {damage} damage!");
-        CheckWinBySurvival();
+        int dmgDealt = defender.TakeDamage(damage);
+        if ( dmgDealt > 0 ) {
+            attacker.totalDamageToOtherPlayers +=  damage;
+            Debug.Log($"{attacker.name} attacked {defender.name} for {damage} damage!");
+            CheckWinBySurvival();
+        }
     }
 
    

--- a/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
@@ -186,8 +186,10 @@ public class GameManager : MonoBehaviour
             if (Globals.selectedGate.Health == 0) {
                 Debug.Log("You broke the gate!");
                 currentState = State.BreakingGate;
-            }
-            else {
+            } else if ( currentPlayer.twoGates ) {
+                currentState = State.ChoosingGate;
+                currentPlayer.twoGates = false;
+            } else {
                 NextTurn();
             }
         }
@@ -196,10 +198,14 @@ public class GameManager : MonoBehaviour
             State? maybeNextState = gateBreak.DoBreakEffect(playerListSO.list[0], Globals.selectedGate, roll);
             Globals.selectedGate.Reset();
 
-            if (maybeNextState is State nextState)
+            if (maybeNextState is State nextState) {
                 currentState = nextState;
-            else
+            } else if ( currentPlayer.twoGates ) {
+                currentState = State.ChoosingGate;
+                currentPlayer.twoGates = false;
+            } else {
                 NextTurn();
+            }
         }
         else if (currentState == State.Battling) {
             if (Globals.battleData.isAttackerRolling) {

--- a/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
@@ -266,6 +266,11 @@ public class GameManager : MonoBehaviour
         while (!players[0].isAlive); // TODO: This will loop infinitely if all players are dead
 
         cardQueue.RepositionCards();
+
+        if ( players[ 0 ].skipMe ) {
+            NextTurn();
+            return;
+        }
         
         currentState = State.TraitRoll;
     }

--- a/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/GameManager.cs
@@ -200,9 +200,10 @@ public class GameManager : MonoBehaviour
 
             if (maybeNextState is State nextState) {
                 currentState = nextState;
-            } else if ( currentPlayer.twoGates ) {
+            } else if ( currentPlayer.twoGates || currentPlayer.directAttack ) {
                 currentState = State.ChoosingGate;
                 currentPlayer.twoGates = false;
+                currentPlayer.directAttack = false;
             } else {
                 NextTurn();
             }

--- a/GatekeeperStudyHall/Assets/Scripts/Globals.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/Globals.cs
@@ -10,6 +10,12 @@ public static class Globals
     /// Holds <c>null</c> if the player has not yet chosen a gate or has already attacked a gate.
     public static GateSO selectedGate = null;
 
+    // the gate the player is choosing to swap with
+    // will use selectedGate as the other half
+    public static GateSO swapGate = null;
+
+    // the player whose gate is being forced
+    public static PlayerSO forcedPlayer = null;
     
     public class BattleData {
         public PlayerSO attacker;

--- a/GatekeeperStudyHall/Assets/Scripts/State.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/State.cs
@@ -21,6 +21,12 @@ public enum State
     
     /// The state where the game waits for the current player to roll to attack another player
     Battling = 5, 
+
+    /// The state where a player is picking two gates to swap
+    SwappingGates = 6,
+
+    /// The state where a player forces another player to choose a gate
+    ForcingGate = 7
 }
 
 
@@ -34,6 +40,8 @@ public static class StateMethods
         State.BreakingGate => true,
         State.ChoosingPlayer => false,
         State.Battling => true,
+        State.SwappingGates => false,
+        State.ForcingGate => false,
         _ => throw new ArgumentOutOfRangeException(nameof(state), state, null)
     };
     
@@ -45,6 +53,8 @@ public static class StateMethods
         State.BreakingGate => false,
         State.ChoosingPlayer => false,
         State.Battling => false,
+        State.SwappingGates => true,
+        State.ForcingGate => true,
         _ => throw new ArgumentOutOfRangeException(nameof(state), state, null)
     };
 }

--- a/GatekeeperStudyHall/Assets/Scripts/TraitHandler.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/TraitHandler.cs
@@ -84,7 +84,7 @@ public class TraitHandler : MonoBehaviour
                     gameManager.currentState = State.ChoosingGate;
                 };
 
-                return State.ChoosingGate;
+                return State.ChoosingPlayer;
 
             case Trait.minus2GateKeeper:
                 //Selected gate health - 2

--- a/GatekeeperStudyHall/Assets/Scripts/TraitHandler.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/TraitHandler.cs
@@ -23,7 +23,8 @@ public enum Trait
     [InspectorName("Choose Gate for Other Player")] chooseGateForOp = 11,
     [InspectorName("Gain Stockade")]                plusStockade = 12,
     [InspectorName("Attack two gates")]             attackTwoGates = 13,
-    [InspectorName("Attack a gate for 1 damage")]   oneDamageToGate = 14
+    [InspectorName("Attack a gate for 1 damage")]   oneDamageToGate = 14,
+    [InspectorName("Skip target player's turn")]    skipTargetTurn = 15
 }
 
 
@@ -167,6 +168,13 @@ public class TraitHandler : MonoBehaviour
                 player.directAttack = true;
                 return State.ChoosingGate;
 
+            case Trait.skipTargetTurn:
+                playerSelection.OnSelect = ( selectedPly ) => {
+                    selectedPly.skipMe = true;
+                    gameManager.currentState = State.ChoosingGate;
+                };
+
+                return State.ChoosingPlayer;
             default:
                 // We shouldn't ever reach this statement.
                 Debug.LogError($"Trait not handled: {trait}");

--- a/GatekeeperStudyHall/Assets/Scripts/TraitHandler.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/TraitHandler.cs
@@ -89,7 +89,8 @@ public class TraitHandler : MonoBehaviour
                 //Selected gate health - 2
                 //GameManager.GateChangeHealth(player, selectedGate,-2);
                 
-                Debug.LogWarning("Trait minus2GateKeeper not implemented");
+                //Debug.LogWarning("Trait minus2GateKeeper not implemented");
+                gameManager.PlayerAttacksCenterGate( player, 2 );
                 break;
 
             case Trait.plus1Health:
@@ -123,8 +124,7 @@ public class TraitHandler : MonoBehaviour
 
             case Trait.swapGateHP:
                 // Swap the HP of two chosen gates
-                Debug.LogWarning("Trait swapGateHP not implemented");
-                break;
+                return State.SwappingGates;
 
             case Trait.increaseGateDamage:
                 // Player deals 1 more damage to gates this turn
@@ -145,8 +145,12 @@ public class TraitHandler : MonoBehaviour
             case Trait.chooseGateForOp:
                 // Choose a gate for another player to attack
                 // that player will only be able to attack that gate during their next turn
-                Debug.LogWarning("Trait chooseGateForOp not implemented");
-                break;
+                Debug.Log("Select a player to force gate");
+                playerSelection.OnSelect = ( selectedPly ) => {
+                    Globals.forcedPlayer = selectedPly;
+                    gameManager.currentState = State.ForcingGate;
+                };
+                return State.ChoosingPlayer;
 
             case Trait.plusStockade:
                 player.hasStockade = true;

--- a/GatekeeperStudyHall/Assets/Scripts/TraitHandler.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/TraitHandler.cs
@@ -22,6 +22,7 @@ public enum Trait
     [InspectorName("Deal 1 Damage to Everyone")]    allMinus1HP = 10,
     [InspectorName("Choose Gate for Other Player")] chooseGateForOp = 11,
     [InspectorName("Gain Stockade")]                plusStockade = 12,
+    [InspectorName("Attack two gates")]             attackTwoGates = 13
 }
 
 
@@ -155,6 +156,10 @@ public class TraitHandler : MonoBehaviour
             case Trait.plusStockade:
                 player.hasStockade = true;
                 player.totalStockade++;
+                break;
+
+            case Trait.attackTwoGates:
+                player.twoGates = true;
                 break;
 
             default:

--- a/GatekeeperStudyHall/Assets/Scripts/TraitHandler.cs
+++ b/GatekeeperStudyHall/Assets/Scripts/TraitHandler.cs
@@ -22,7 +22,8 @@ public enum Trait
     [InspectorName("Deal 1 Damage to Everyone")]    allMinus1HP = 10,
     [InspectorName("Choose Gate for Other Player")] chooseGateForOp = 11,
     [InspectorName("Gain Stockade")]                plusStockade = 12,
-    [InspectorName("Attack two gates")]             attackTwoGates = 13
+    [InspectorName("Attack two gates")]             attackTwoGates = 13,
+    [InspectorName("Attack a gate for 1 damage")]   oneDamageToGate = 14
 }
 
 
@@ -161,6 +162,10 @@ public class TraitHandler : MonoBehaviour
             case Trait.attackTwoGates:
                 player.twoGates = true;
                 break;
+
+            case Trait.oneDamageToGate:
+                player.directAttack = true;
+                return State.ChoosingGate;
 
             default:
                 // We shouldn't ever reach this statement.


### PR DESCRIPTION
_Note:  This was originally the "Add More Traits" issue/branch but I misunderstood and just ended up implementing the unimplemented traits._

Implements (checked items are tested and confirmed working):

- [x] Force another player to attack a gate
- [x] Swap HP of two gates
- [x] Attack the Gatekeeper for 2 HP
- [x] Attack two gates this turn
- [x] Attack a target gate for 1 HP
- [x] Skip a target player's turn

Major changes:
- Adds an "INVALID" enum to GateColor at -1 to help determine which gate the player is forced to attack
- Adds a static iPlayerListSO in GameManager to access it anywhere without a serialized field; **this might be dumb**
- Adds an extra chunk of text to the debug text for the swapping gate
- Adds two more states:  ForcingGate and SwappingGates
- Adds twoGates to PlayerSO to determine whether the player should be able to attack two gates
- Adds directAttack to PlayerSO to determine whether the player is doing a direct, roll-less attack on a gate

There's a whole bunch of gross stuff in GateButtonActions.cs that I definitely feel could be improved/refactored/beautified but it works so I'm just gonna leave it alone.